### PR TITLE
Fix thumbnailURL() to return high quality thumbnails for videos

### DIFF
--- a/Zype/Helpers/SDKHelpers.swift
+++ b/Zype/Helpers/SDKHelpers.swift
@@ -21,7 +21,7 @@ extension VideoModel {
             }
         }
     }
-    return nil
+    return  NSURL(string: "")
   }
 
   func posterURL() -> NSURL? {

--- a/Zype/Helpers/SDKHelpers.swift
+++ b/Zype/Helpers/SDKHelpers.swift
@@ -11,23 +11,26 @@ import UIKit
 import ZypeSDK
 
 extension VideoModel {
-  
+
   func thumbnailURL() -> NSURL? {
     if(self.thumbnails.count > 0){
-      if let url = thumbnails.first?.imageURL {
-        return NSURL(string: url)
-      }
+        for thumbnail in thumbnails {
+            if thumbnail.width > 250 {
+                let url = thumbnail.imageURL
+                return NSURL(string: url)
+            }
+        }
     }
     return nil
   }
-  
+
   func posterURL() -> NSURL? {
     if let model = self.getThumbnailByHeight(1080) {
       return NSURL(string: model.imageURL)
     }
     return nil
   }
-  
+
   func isInFavorites() -> Bool{
     let defaults = NSUserDefaults.standardUserDefaults()
     if let favorites = defaults.arrayForKey(Const.kFavoritesKey) as? Array<String> {
@@ -35,7 +38,7 @@ extension VideoModel {
     }
     return false
   }
-  
+
   func toggleFavorite() {
     let defaults = NSUserDefaults.standardUserDefaults()
     var favorites = defaults.arrayForKey(Const.kFavoritesKey) as? Array<String> ?? [String]()
@@ -47,5 +50,5 @@ extension VideoModel {
     defaults.setObject(favorites, forKey: Const.kFavoritesKey)
     defaults.synchronize()
   }
-  
+
 }


### PR DESCRIPTION
This change to thumbnailURL() ensures that it returns URLs to video thumbnails with the width higher than 250px
