### PR TITLE
Update for XCode 9.3 build error

### DIFF
--- a/AVOD/KissXML/DDXMLDocument.m
+++ b/AVOD/KissXML/DDXMLDocument.m
@@ -1,5 +1,6 @@
 #import "DDXMLPrivate.h"
 #import "NSString+DDXML.h"
+#import <libxml/parser.h>
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).

--- a/Zype/Const.swift
+++ b/Zype/Const.swift
@@ -69,7 +69,7 @@ class Const: NSObject {
     static let kFavoritesKey = "Favorites"
     static let kDefaultsRootPlaylistId = "root_playlist_id"
     static let kDefaultsBackgroundUrl = "background_url"
-    static let kAppVersion = "1.2.3"
+    static let kAppVersion = "1.2.4"
     
     // MARK: - Segues
     


### PR DESCRIPTION
Update fixes compilation error when using latest XCode version (9.3). Users were getting the following error when running app in XCode simulator:

<img width="264" alt="screen shot 2018-04-13 at 10 40 14 am" src="https://user-images.githubusercontent.com/18153785/38815073-11c18f34-4161-11e8-9ff7-fc1a2d63b53f.png">

Found the solution in [KissXML PR #94](https://github.com/robbiehanson/KissXML/pull/94)