### PR TITLE
 Add new viewer registration flow before allowing video playback

### DIFF
--- a/Zype/Base.lproj/Localizable.strings
+++ b/Zype/Base.lproj/Localizable.strings
@@ -14,6 +14,7 @@
 "ShowDetails.SubscribeLoginNeeded" = "Please login before subscribing";
 "ShowDetails.SubscribeToWatchAdFree" = "Watch Ad Free";
 "ShowDetails.WatchTrailer" = "Watch Trailer";
+"ShowDetails.SignupButton" = "Sign Up";
 
 "Favorites.TabTitle" = "Favorites";
 "Favorites.Title" = "Favorites";

--- a/Zype/View Controllers/BaseCollectionVC.swift
+++ b/Zype/View Controllers/BaseCollectionVC.swift
@@ -299,6 +299,10 @@ extension BaseCollectionVC {
             }
             return cell
         }
+        //check for index out of bounds when data is being fetched after signout
+        if section.items?.count == 0 {
+            return collectionView.dequeueReusableCell(withReuseIdentifier: (section.isPager ? "PagerCell" :"ImageCell"), for: indexPath)
+        }
         
         let data = section.items[self.isInfinityScrolling ? (indexPath.row % self.sections[indexPath.section].items.count) : indexPath.row]
         

--- a/Zype/View Controllers/CollectionContainerVC.swift
+++ b/Zype/View Controllers/CollectionContainerVC.swift
@@ -101,6 +101,13 @@ extension UIViewController {
             //custom logic for a livestream can be placed here
         }
         
+        if model.registrationRequired {
+            if !ZypeUtilities.isDeviceLinked() {
+                ZypeUtilities.presentRegisterVC(self)
+                return
+            }
+        }
+        
         //logic for subscription that can be native or universal
         //for native subscription the check will be performed on video play level
         if Const.kNativeSubscriptionEnabled == false {

--- a/Zype/View Controllers/ShowDetailsVC.swift
+++ b/Zype/View Controllers/ShowDetailsVC.swift
@@ -257,6 +257,9 @@ class ShowDetailsVC: CollectionContainerVC {
             case .watchTrailer:
                 actionable.button.setBackgroundImage(UIImage(named: "WatchTrailer"), for: .normal)
                 actionable.label.text = localized("ShowDetails.WatchTrailer")
+            case .signup:
+                actionable.button.setBackgroundImage(UIImage(named: "Subscribed"), for: .normal)
+                actionable.label.text = localized("ShowDetails.SignupButton")
             }
         }
         
@@ -318,6 +321,8 @@ class ShowDetailsVC: CollectionContainerVC {
             self.handleFavorites()
         case .watchTrailer:
             self.handleTrailer()
+        case .signup:
+            self.handleRegisteration()
         }
     }
     
@@ -404,6 +409,10 @@ class ShowDetailsVC: CollectionContainerVC {
             
         }
     }
+    
+    fileprivate func handleRegisteration() {
+        ZypeUtilities.presentRegisterVC(self)
+    }
 }
 
 
@@ -432,6 +441,7 @@ extension ShowDetailsVC {
         case purchase
         case favorite
         case watchTrailer
+        case signup
     }
     
     func getCurrentActionables() {
@@ -467,7 +477,12 @@ extension ShowDetailsVC {
     }
     
     fileprivate func getPlayMonetizationButton() -> ButtonType {
-        if selectedVideo.subscriptionRequired {
+        if selectedVideo.registrationRequired {
+            if !ZypeUtilities.isDeviceLinked() {
+                return .signup
+            }
+        }
+        else if selectedVideo.subscriptionRequired {
             if Const.kNativeTvod && selectedVideo.purchaseRequired && userHasEntitlement() {
                 return .play
             }


### PR DESCRIPTION
1. Detail screen enhancement for signup support before video playback.

2. Search screen enhancement for signup support before video playback.

3. Priority of registration is assumed higher than subscription, if any video requires both registration and subscription than registration flow (sign-up) is invoked first at Search screen.

4. Fixed  crash due to index out of bounds exception at home page while accessing parent playlist just after the sign out from settings.