### PR TITLE
Add [device_ua] macro to the replaceAdMacros function

### DIFF
--- a/Zype/Helpers/AdProtocolDelegate.swift
+++ b/Zype/Helpers/AdProtocolDelegate.swift
@@ -78,6 +78,8 @@ extension PlayerVC: AdHelperProtocol {
         if let ifa = deviceIfa {
             string = (string as NSString).replacingOccurrences(of: "[device_ifa]", with: "\(ifa)")
         }
+        string = (string as NSString).replacingOccurrences(of: "[device_ua]", with: "\(ZypeUserAgentBuilder.buildtUserAgent().userAgent().addingPercentEncoding(withAllowedCharacters: CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[]{} ").inverted) ?? "")")
+
         string = (string as NSString).replacingOccurrences(of: "[vpi]", with: "\(vpi)")
         string = (string as NSString).replacingOccurrences(of: "[app_id]", with: "\(appId)")
         

--- a/Zype/Helpers/AdProtocolDelegate.swift
+++ b/Zype/Helpers/AdProtocolDelegate.swift
@@ -66,22 +66,22 @@ extension PlayerVC: AdHelperProtocol {
         let vpi = "mp4"
         let appId = ZypeAppSettings.sharedInstance.deviceId()
         
-        string = (string as NSString).replacingOccurrences(of: "[uuid]", with: "\(uuid)")
-        string = (string as NSString).replacingOccurrences(of: "[app_name]", with: "\(appName)")
+        string = (string as NSString).replacingOccurrences(of: "[uuid]", with: "\(uuid.encodeUrlQueryParam())")
+        string = (string as NSString).replacingOccurrences(of: "[app_name]", with: "\(appName.encodeUrlQueryParam())")
         if let bundle = appBundle {
-            string = (string as NSString).replacingOccurrences(of: "[app_bundle]", with: "\(bundle)")
-            string = (string as NSString).replacingOccurrences(of: "[app_domain]", with: "\(bundle)")
+            string = (string as NSString).replacingOccurrences(of: "[app_bundle]", with: "\(bundle)".encodeUrlQueryParam())
+            string = (string as NSString).replacingOccurrences(of: "[app_domain]", with: "\(bundle)".encodeUrlQueryParam())
         }
-        string = (string as NSString).replacingOccurrences(of: "[device_type]", with: "\(deviceType)")
-        string = (string as NSString).replacingOccurrences(of: "[device_make]", with: "\(deviceMake)")
-        string = (string as NSString).replacingOccurrences(of: "[device_model]", with: "\(deviceModel)")
+        string = (string as NSString).replacingOccurrences(of: "[device_type]", with: "\(deviceType)".encodeUrlQueryParam())
+        string = (string as NSString).replacingOccurrences(of: "[device_make]", with: "\(deviceMake)".encodeUrlQueryParam())
+        string = (string as NSString).replacingOccurrences(of: "[device_model]", with: "\(deviceModel)".encodeUrlQueryParam())
         if let ifa = deviceIfa {
-            string = (string as NSString).replacingOccurrences(of: "[device_ifa]", with: "\(ifa)")
+            string = (string as NSString).replacingOccurrences(of: "[device_ifa]", with: "\(ifa)".encodeUrlQueryParam())
         }
-        string = (string as NSString).replacingOccurrences(of: "[device_ua]", with: "\(ZypeUserAgentBuilder.buildtUserAgent().userAgent().addingPercentEncoding(withAllowedCharacters: CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[]{} ").inverted) ?? "")")
+        string = (string as NSString).replacingOccurrences(of: "[device_ua]", with: "\(ZypeUserAgentBuilder.buildtUserAgent().userAgent().encodeUrlQueryParam())")
 
-        string = (string as NSString).replacingOccurrences(of: "[vpi]", with: "\(vpi)")
-        string = (string as NSString).replacingOccurrences(of: "[app_id]", with: "\(appId)")
+        string = (string as NSString).replacingOccurrences(of: "[vpi]", with: "\(vpi)".encodeUrlQueryParam())
+        string = (string as NSString).replacingOccurrences(of: "[app_id]", with: "\(appId)".encodeUrlQueryParam())
         
         return string
     }

--- a/Zype/Helpers/Utils.swift
+++ b/Zype/Helpers/Utils.swift
@@ -125,3 +125,12 @@ extension UIColor {
     }
 }
 
+extension String {
+    
+    func encodeUrlQueryParam() -> String {
+        return self.addingPercentEncoding(
+            withAllowedCharacters: CharacterSet(
+                charactersIn: "!*'();:@&=+$,/?%#[]{} ").inverted)
+            ?? self
+    }
+}


### PR DESCRIPTION
The goal of this PR is to add the string replacement logic in https://github.com/zype/zype-apple-tv/blob/6175f37ccc55216b05dac14119336e5fd9f05797/Zype/Helpers/AdProtocolDelegate.swift#L56 in a way that this macro occurrence is then replaced with the device user-agent information that’s already generated in the app template today.