### PR TITLE
tvOS 14 Crash Resolution

### DIFF
--- a/Zype/View Controllers/SearchVC.swift
+++ b/Zype/View Controllers/SearchVC.swift
@@ -35,7 +35,8 @@ class SearchVC: UISearchContainerViewController, UISearchControllerDelegate, UIS
     override internal var searchController: UISearchController {
         get {
             if self.cachedVC == nil {
-                self.collectionVC = self.storyboard?.instantiateViewController(withIdentifier: "BaseCollectionVC") as! BaseCollectionVC
+                let storyboard = self.storyboard ?? UIStoryboard(name: "Main", bundle: nil)
+                self.collectionVC = storyboard.instantiateViewController(withIdentifier: "BaseCollectionVC") as? BaseCollectionVC
                 self.collectionVC.configWithSections([CollectionSection()])
                 self.collectionVC.itemSelectedCallback = { (item: CollectionLabeledItem, section: CollectionSection) in
                     self.playVideo(item.object as! VideoModel)


### PR DESCRIPTION
Root Cause -
storyboard property on UIViewController is nil on tvOS 14.x until view life cycle is completed for any UIViewController. We were accessing this property in SearchVC before viewDidLoad hence causing crash issue on tvOS 14 as we were using non optionals in swift.

Fix -
Applied generic fix by loading storyboard using APIs if storyboard property is nil. After the fix verified the build on older and newer tvOS versions (12.x 14.x) and working fine.