### PR TITLE
Fix for xcframework build issues on XCode 12.3

### DIFF
--- a/Zype.xcodeproj/project.pbxproj
+++ b/Zype.xcodeproj/project.pbxproj
@@ -800,6 +800,7 @@
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 11.0;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;
 		};
@@ -826,6 +827,7 @@
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 11.0;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This is not recommended approach but this should work until we manage to have an xcframework version of the analytics framework. 